### PR TITLE
Streamline menu handler.

### DIFF
--- a/src/coe/coe.ts
+++ b/src/coe/coe.ts
@@ -14,7 +14,7 @@ import {CoeSimulationRunner} from './CoeSimulationRunner'
 import {IProject} from "../proj/IProject";
 import {SettingKeys} from "../settings/SettingKeys";
 import {SourceDom} from "../sourceDom"
-import {IViewController} from "../iViewController"
+import {ViewController} from "../iViewController"
 
 import {CoSimulationConfig, Serializer} from "../intocps-configurations/intocps-configurations";
 
@@ -26,7 +26,7 @@ import * as Configs from "../intocps-configurations/intocps-configurations";
 import {Utilities} from "../utilities";
 import {LivestreamConfiguration} from "./livestream/livestream-config";
 
-export class CoeController extends IViewController {
+export class CoeController extends ViewController {
 
     coSimConfig: CoSimulationConfig = null;
 
@@ -61,14 +61,14 @@ export class CoeController extends IViewController {
 
     app: IntoCpsApp;
 
-    constructor(viewDiv: HTMLDivElement) {
+    constructor(viewDiv: HTMLDivElement, private path:string) {
         super(viewDiv);
         this.remote = require("electron").remote;
         this.dialog = this.remote.dialog;
         this.app = IntoCpsApp.getInstance();
     }
 
-    initialize(sourceDom: SourceDom): void {
+    initialize(): void {
         this.startTimeContainer = <HTMLElement>this.viewDiv.querySelector("#startTime");
         this.endTimeContainer = <HTMLElement>this.viewDiv.querySelector("#endTime");
         this.dropDownContainer = <HTMLElement>this.viewDiv.querySelector("#dropdown");
@@ -90,7 +90,7 @@ export class CoeController extends IViewController {
             console.warn("no active project cannot load coe config");
         }
 
-        CoSimulationConfig.parse(sourceDom.getPath(), activeProject.getRootFilePath(), activeProject.getFmusPath())
+        CoSimulationConfig.parse(this.path, activeProject.getRootFilePath(), activeProject.getFmusPath())
             .then(cc => {
                 console.info("CC:"); console.info(cc);
                 this.coSimConfig = cc;

--- a/src/dse/dse.ts
+++ b/src/dse/dse.ts
@@ -1,8 +1,8 @@
 import {IntoCpsApp} from "../IntoCpsApp"
 import {SourceDom} from "../sourceDom"
-import {IViewController} from "../iViewController"
+import {ViewController} from "../iViewController"
 
-export class DseController extends IViewController {
+export class DseController extends ViewController {
 
     private doNotPressButton: HTMLButtonElement;
 

--- a/src/iViewController.ts
+++ b/src/iViewController.ts
@@ -1,10 +1,8 @@
-import {SourceDom} from "./sourceDom";
-
 export interface IViewController {
-    initialize?(sourceDom: SourceDom): void;
+    initialize?(): void;
     deInitialize?(): boolean;
 }
 
-export abstract class IViewController {
+export abstract class ViewController implements IViewController {
     constructor(protected viewDiv: HTMLDivElement) {};
 }

--- a/src/multimodel/MmController.ts
+++ b/src/multimodel/MmController.ts
@@ -16,7 +16,7 @@ import {Parameters} from "./parameters/parameters";
 import {IProject} from "../proj/IProject";
 import {SettingKeys} from "../settings/SettingKeys";
 import {ListElement} from "./connections/list-element";
-import {IViewController} from "../iViewController";
+import {ViewController} from "../iViewController";
 import {SourceDom} from "../sourceDom";
 import {FmuInstancesElement} from "./connections/fmu-instances-element";
 import {ConnectionsElement} from "./connections/connections-element";
@@ -31,7 +31,7 @@ enum MmContainers {
     Keys = 1 << 3,
 }
 
-export class MmController extends IViewController {
+export class MmController extends ViewController {
     mm: MultiModelConfig = new MultiModelConfig();
     private multiModelFmusDiv: HTMLDivElement;
     private fmuAddButton: HTMLButtonElement;
@@ -49,11 +49,11 @@ export class MmController extends IViewController {
     private saveButton: HTMLButtonElement;
 
 
-    constructor(mainViewDiv: HTMLDivElement) {
+    constructor(mainViewDiv: HTMLDivElement, private path:string) {
         super(mainViewDiv);
     }
 
-    initialize(sourceDom: SourceDom) {
+    initialize() {
         IntoCpsApp.IntoCpsApp.setTopName("Multi-Model");
 
         this.fmuInstancesDiv = <HTMLDivElement>document.getElementById("multimodel-fmu-instances");
@@ -72,7 +72,7 @@ export class MmController extends IViewController {
             console.log("project-changed");  // prints "ping"
 
         });
-        this.load(sourceDom.getPath());
+        this.load(this.path);
     }
 
     deInitialize() {

--- a/src/rttester/CreateMCProject.ts
+++ b/src/rttester/CreateMCProject.ts
@@ -1,6 +1,6 @@
 
 import {SourceDom} from "../sourceDom";
-import {IViewController} from "../iViewController";
+import {ViewController} from "../iViewController";
 import {IntoCpsApp} from "../IntoCpsApp"
 import * as Settings from  "../settings/settings"
 import {SettingKeys} from "../settings/SettingKeys";
@@ -143,7 +143,7 @@ class Abstractions {
 
 
 
-export class CreateMCProjectController extends IViewController {
+export class CreateMCProjectController extends ViewController {
 
     directory: string;
     abstractions: Abstractions;

--- a/src/rttester/CreateTDGProject.ts
+++ b/src/rttester/CreateTDGProject.ts
@@ -1,6 +1,6 @@
 
 import {SourceDom} from "../sourceDom";
-import {IViewController} from "../iViewController";
+import {ViewController} from "../iViewController";
 import {IntoCpsApp} from "../IntoCpsApp"
 import * as Settings from  "../settings/settings"
 import {SettingKeys} from "../settings/SettingKeys";
@@ -8,7 +8,7 @@ import Path = require('path');
 import {RTTester} from "../rttester/RTTester";
 
 
-export class CreateTDGProjectController extends IViewController {
+export class CreateTDGProjectController extends ViewController {
 
     directory: string;
 

--- a/src/rttester/LTLEditor.ts
+++ b/src/rttester/LTLEditor.ts
@@ -4,7 +4,7 @@
 
 
 import {SourceDom} from "../sourceDom";
-import {IViewController} from "../iViewController";
+import {ViewController} from "../iViewController";
 import {IntoCpsApp} from "../IntoCpsApp"
 import * as Settings from  "../settings/settings"
 import {SettingKeys} from "../settings/SettingKeys";
@@ -13,7 +13,7 @@ import {RTTester} from "../rttester/RTTester";
 import fs = require("fs");
 
 
-export class LTLEditorController extends IViewController {
+export class LTLEditorController extends ViewController {
 
     fileName: string;
     json: any = {};

--- a/src/rttester/RunTest.ts
+++ b/src/rttester/RunTest.ts
@@ -1,6 +1,6 @@
 
 import {SourceDom} from "../sourceDom";
-import {IViewController} from "../iViewController";
+import {ViewController} from "../iViewController";
 import {IntoCpsApp} from "../IntoCpsApp"
 import * as Settings from  "../settings/settings"
 import {SettingKeys} from "../settings/SettingKeys";
@@ -74,7 +74,7 @@ class FMUAssignments {
     }
 }
 
-export class RunTestController extends IViewController {
+export class RunTestController extends ViewController {
 
     testCase: string;
     fmuAssignments: FMUAssignments = new FMUAssignments(this);


### PR DESCRIPTION
This is a proposal for streamlining the menu handler, so that loading pages is handled by one function.

This allows pages with a ViewController to detect when a page load is about to happen and to cancel it if necessary.

This is needed for implementing a "Do you want to save your changes before leaving the page?" prompt on the coe and mm configuration pages.



Loading a new page is handled by the openView function which takes the html file path and a callback as parameters.

The callback is called with the main view html element.
A controller can be returned from the callback to let the openView function initialize it.

I have also removed the SourceDom parameter from the initialize method, since no controller is using it and it made the implementation easier.



I have clicked around in the app on windows and nothing seems to be broken by this implementation... :-)