### PR TITLE
Improved ui coe error + result status indication

### DIFF
--- a/src/angular2-app/coe/coe-simulation.component.ts
+++ b/src/angular2-app/coe/coe-simulation.component.ts
@@ -127,7 +127,8 @@ export class CoeSimulationComponent implements OnInit, OnDestroy {
 
         this.hasHttpError = hasError;
         this.httpErrorMessage = message;
-
+        if(hasError)
+            this.simulating = false;
     }
 
     postScriptOutputHandler(hasError: boolean, message: string) {

--- a/src/angular2-app/coe/coe-simulation.service.ts
+++ b/src/angular2-app/coe/coe-simulation.service.ts
@@ -8,6 +8,7 @@ import * as Path from "path";
 import { BehaviorSubject } from "rxjs/Rx";
 import { Injectable, NgZone } from "@angular/core";
 import { CoSimulationConfig } from "../../intocps-configurations/CoSimulationConfig";
+import { storeResultCrc } from "../../intocps-configurations/ResultConfig";
 import * as http from "http"
 import * as fs from 'fs'
 import * as child_process from 'child_process'
@@ -229,6 +230,7 @@ export class CoeSimulationService {
                     this.fileSystem.copyFile(this.config.multiModel.sourcePath, mmConfigPath)
                 ]).then(() => {
                     this.progress = 100;
+                    storeResultCrc(resultPath,this.config);
                     this.executePostProcessingScript(resultPath);
                 });
             });

--- a/src/coe-server-status/CoeServerStatus.ts
+++ b/src/coe-server-status/CoeServerStatus.ts
@@ -155,7 +155,7 @@ function launchCoe() {
 
 
         if (div.childElementCount > 600)
-            while (div.childElementCount > 500 && div.hasChildNodes()) {
+            while (div.childElementCount > 5000 && div.hasChildNodes()) {
                 div.removeChild(div.firstChild);
             }
         window.scrollTo(0, document.body.scrollHeight);

--- a/src/intocps-configurations/CoSimulationConfig.ts
+++ b/src/intocps-configurations/CoSimulationConfig.ts
@@ -54,7 +54,8 @@ export class CoSimulationConfig implements ISerializable {
             overrideLogLevel: this.overrideLogLevel,
             enableAllLogCategoriesPerInstance: this.enableAllLogCategoriesPerInstance,
             algorithm: this.algorithm.toObject(),
-            postProcessingScript: this.getProjectRelativePath(this.postProcessingScript)
+            postProcessingScript: this.getProjectRelativePath(this.postProcessingScript),
+            multimodel_crc: this.multiModelCrc
         };
     }
 

--- a/src/intocps-configurations/ResultConfig.ts
+++ b/src/intocps-configurations/ResultConfig.ts
@@ -1,0 +1,76 @@
+import { CoSimulationConfig } from "./CoSimulationConfig"
+import * as fs from "fs"
+import * as Path from "path";
+import { checksum } from "../proj/Project";
+
+export function storeResultCrc(outputPath: string, coeConfig: CoSimulationConfig) {
+
+    let coeCrc = checksum(fs.readFileSync(coeConfig.sourcePath).toString(), "md5", "hex");
+    let mmCrc = coeConfig.multiModelCrc;
+    let resultCrc = checksum(fs.readFileSync(outputPath).toString(), "md5", "hex");
+
+    let res = { mm_config_crc: mmCrc, coe_config_crc: coeCrc, output_crc: resultCrc }
+
+    let data = JSON.stringify(res);
+    let file = Path.join(Path.dirname(outputPath), "result.json");
+    console.info(data);
+
+    return new Promise<void>((resolve, reject) => {
+        try {
+
+            fs.writeFile(file, data, error => {
+                if (error)
+                    reject(error);
+                else
+                    resolve();
+            });
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+export function isResultValid(outputPath: string): boolean {
+
+    let dir = Path.dirname(outputPath);
+    let resultPath = Path.join(dir, "result.json");
+
+    if (!fs.existsSync(resultPath)) {
+        return true;//no check
+    }
+
+    let data = fs.readFileSync(resultPath, 'utf8');
+
+    let obj = JSON.parse(data);
+    //let res = { mm_config_crc: mmCrc, coe_config: coeCrc, result: resultCrc }
+    let ok = true;
+
+    let mmCrc = obj["mm_config_crc"];
+    if (mmCrc != null) {
+        let mmPath = Path.join(dir, "..", "..", "mm.json")
+        //console.debug("MM path: " + mmPath);
+        let crc = checksum(fs.readFileSync(mmPath).toString(), "md5", "hex");
+        //console.debug("crc: " + mmCrc + " == " + crc);
+        ok = ok && (crc == mmCrc);
+    }
+    let coeCrc = obj["coe_config_crc"];
+    if (coeCrc != null) {
+        let coePath = Path.join(dir, "..", "coe.json")
+        //console.debug("COE path: " + coePath);
+        let crc = checksum(fs.readFileSync(coePath).toString(), "md5", "hex");
+        //console.debug("crc: " + coeCrc + " == " + crc);
+        ok = ok && (crc == coeCrc);
+
+    }
+    let outputCrc = obj["output_crc"];
+    if (outputCrc != null) {
+        //console.debug("Output path: " + outputPath);
+        let crc = checksum(fs.readFileSync(outputPath).toString(), "md5", "hex");
+        //console.debug("crc: " + outputCrc + " == " + crc);
+        ok = ok && (crc == outputCrc);
+
+    }
+
+
+    return ok;
+}

--- a/src/intocps-configurations/ResultConfig.ts
+++ b/src/intocps-configurations/ResultConfig.ts
@@ -55,7 +55,15 @@ export function isResultValid(outputPath: string): boolean {
     }
     let coeCrc = obj["coe_config_crc"];
     if (coeCrc != null) {
+        
         let coePath = Path.join(dir, "..", "coe.json")
+        if(!fs.existsSync(coePath))
+        {
+                //Backwards compatibility
+                let file = fs.readdirSync(Path.join(dir, "..")).find(file => file.endsWith("coe.json"));
+                coePath = Path.join(dir,"..",file);
+                console.debug("Found old style coe at: " + coePath);
+        }
         //console.debug("COE path: " + coePath);
         let crc = checksum(fs.readFileSync(coePath).toString(), "md5", "hex");
         //console.debug("crc: " + coeCrc + " == " + crc);

--- a/src/proj/projbrowserview.ts
+++ b/src/proj/projbrowserview.ts
@@ -1,15 +1,16 @@
 ///<reference path="../../typings/browser/ambient/jquery/index.d.ts"/>
 ///<reference path="../../typings/browser/ambient/w2ui/index.d.ts"/>
 
-import {IntoCpsAppEvents} from "../IntoCpsAppEvents";
-import {IntoCpsApp} from  "../IntoCpsApp";
-import {Project} from "./Project";
+import { IntoCpsAppEvents } from "../IntoCpsAppEvents";
+import { IntoCpsApp } from "../IntoCpsApp";
+import { Project } from "./Project";
+import { isResultValid } from "../intocps-configurations/ResultConfig";
 import * as fs from 'fs';
 import Path = require("path");
 const rimraf = require("rimraf");
-import {RTTester} from "../rttester/RTTester";
-import {IntoCpsAppMenuHandler} from "../IntoCpsAppMenuHandler";
-import {Utilities} from "../utilities";
+import { RTTester } from "../rttester/RTTester";
+import { IntoCpsAppMenuHandler } from "../IntoCpsAppMenuHandler";
+import { Utilities } from "../utilities";
 import * as CopyTestProcedureDialog from "../rttester/CopyTestProcedureDialog";
 
 
@@ -353,8 +354,8 @@ export class BrowserController {
                 result.img = "into-cps-icon-projbrowser-dse-result";
                 result.removeFileExtensionFromText();
                 result.dblClickHandler = function (item: ProjectBrowserItem) {
-                     self.menuHandler.openHTMLInMainView(item.path,"DSE Results View");
-                
+                    self.menuHandler.openHTMLInMainView(item.path, "DSE Results View");
+
                     return null;
                 };
             }
@@ -438,7 +439,12 @@ export class BrowserController {
                 };
             }
             else if (path.endsWith(".csv")) {
-                result.img = "into-cps-icon-projbrowser-result";
+                if (isResultValid(path)) {
+                    result.img = "into-cps-icon-projbrowser-result";
+                }
+                else {
+                    result.img = "glyphicon glyphicon-remove";
+                }
                 result.removeFileExtensionFromText();
                 result.dblClickHandler = function (item: ProjectBrowserItem) {
                     self.menuHandler.openWithSystemEditor(item.path);


### PR DESCRIPTION
This flips the simulate button back to simulate if an error occurs (from stop) and increases the console log of the COE view to 5000 lines (before it only allowed 500). It also includes code to indicate if results still are valid e.g. if the mm or coe config is change the result folder gets a different icon indicating that it is invalid,