### PR TITLE
added proper handling of download actions #244

### DIFF
--- a/src/downloadManager/DownloadManager.ts
+++ b/src/downloadManager/DownloadManager.ts
@@ -221,19 +221,25 @@ function showVersion(version: string, data: any) {
                         //Start the download
                         downloader.downloadTool(tool, getTempDir(), progressFunction(tool.name, component)).then(function (filePath) {
                             console.log("Download complete: " + filePath);
-                            const {shell} = require('electron');
-                            
-                            if (downloader.checkToolAction(tool,downloader.DownloadAction.UNPACK)) {
+                            const { shell } = require('electron');
+
+                            if (downloader.checkToolAction(tool, downloader.DownloadAction.UNPACK)) {
                                 let installDirectory = IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_DIR)
                                 downloader.unpackTool(filePath, installDirectory);
                                 shell.showItemInFolder(installDirectory);
-                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.LAUNCH)) {
-                                shell.openExternal(filePath);
-                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.SHOW)) {
+                            } else if (downloader.checkToolAction(tool, downloader.DownloadAction.LAUNCH)) {
+                                dialog.showMessageBox({ type: 'question', buttons: buttons, message: "Accept launch of installer: " + Path.basename(filePath) + " downloaded for: " + tool.name + " (" + tool.version + ")" }, function (buttonInstall: any) {
+                                    if (buttonInstall == 1)//yes
+                                    {
+                                        shell.openExternal(filePath);
+                                    }
+                                });
+
+                            } else if (downloader.checkToolAction(tool, downloader.DownloadAction.SHOW)) {
                                 shell.showItemInFolder(filePath);
-                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.NONE)) {
+                            } else if (downloader.checkToolAction(tool, downloader.DownloadAction.NONE)) {
                                 //do nothing
-                            }else {
+                            } else {
                                 dialog.showMessageBox({ type: 'info', buttons: ["OK"], message: "Download completed: " + filePath }, function (button: any) { });
                             }
                         }, function (error) { dialog.showErrorBox("Invalid Checksum", error); });

--- a/src/downloadManager/DownloadManager.ts
+++ b/src/downloadManager/DownloadManager.ts
@@ -221,10 +221,20 @@ function showVersion(version: string, data: any) {
                         //Start the download
                         downloader.downloadTool(tool, getTempDir(), progressFunction(tool.name, component)).then(function (filePath) {
                             console.log("Download complete: " + filePath);
-                            dialog.showMessageBox({ type: 'info', buttons: ["OK"], message: "Download completed: " + filePath }, function (button: any) { });
-                            if (downloader.toolRequiresUnpack(tool)) {
+                            const {shell} = require('electron');
+                            
+                            if (downloader.checkToolAction(tool,downloader.DownloadAction.UNPACK)) {
                                 let installDirectory = IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_DIR)
                                 downloader.unpackTool(filePath, installDirectory);
+                                shell.showItemInFolder(installDirectory);
+                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.LAUNCH)) {
+                                shell.openExternal(filePath);
+                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.SHOW)) {
+                                shell.showItemInFolder(filePath);
+                            }else if (downloader.checkToolAction(tool,downloader.DownloadAction.NONE)) {
+                                //do nothing
+                            }else {
+                                dialog.showMessageBox({ type: 'info', buttons: ["OK"], message: "Download completed: " + filePath }, function (button: any) { });
                             }
                         }, function (error) { dialog.showErrorBox("Invalid Checksum", error); });
                     });

--- a/src/downloader/Downloader.ts
+++ b/src/downloader/Downloader.ts
@@ -9,6 +9,14 @@ let hash = require("md5-promised");
 let yauzl = require("yauzl");
 let mkdirp = require("mkdirp");
 
+export namespace DownloadAction {
+    export var UNPACK = "unpack";
+    export var LAUNCH = "launch";
+    export var SHOW = "show";
+    export var NONE = "none";
+}
+
+
 export function getSystemPlatform() {
     let arch: string = Utilities.getSystemArchitecture();
     if (!(arch === "32" || arch === "64"))
@@ -102,10 +110,10 @@ function launchToolInstaller(filePath: string) {
 }
 
 
-export function toolRequiresUnpack(tool: any){
+export function checkToolAction(tool: any, testAction:string) {
     let platFormToUse = tool.platforms.any ? "any" : SYSTEM_PLATFORM;
     const action: string = tool.platforms[platFormToUse].action;
-    return action === "unpack";
+    return action === testAction;
 }
 
 export function unpackTool(filePath: string, targetDirectory: string) {


### PR DESCRIPTION
Hi I added better handling of the download actions, instead of just a message box now it actually does: launch, unpack+show, show, none (nothing). Show requests the desktop to show the location/ file in the browser.

People seems not to not know how to get to the downloaded stuff or where it end up even though we show the location.