### PR TITLE
Add fmu export feature in the app for overture

### DIFF
--- a/src/IntoCpsAppMenuHandler.ts
+++ b/src/IntoCpsAppMenuHandler.ts
@@ -34,4 +34,5 @@ export class IntoCpsAppMenuHandler {
     rename: (path:string)=>void;
 
     showTraceView: () =>void;
+    exportOvertureFmu: (type: string, path: string)=>void;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -17,9 +17,9 @@ import { bootstrap } from '@angular/platform-browser-dynamic';
 import { AppComponent } from './angular2-app/app.component';
 import * as fs from 'fs';
 import * as Path from 'path';
-import { DseConfiguration } from "./intocps-configurations/dse-configuration"
-
-import {TraceMessager} from "./traceability/trace-messenger"
+import { DseConfiguration } from "./intocps-configurations/dse-configuration";
+import {Overture} from "./overture";
+import {TraceMessager} from "./traceability/trace-messenger";
 
 interface MyWindow extends Window {
     ng2app: AppComponent;
@@ -360,6 +360,8 @@ menuHandler.showTraceView = () => {
     renameHandler.openWindow();
     menuHandler.openHTMLInMainView("http://localhost:7474/browser/","Traceability Graph View");
 };
+
+menuHandler.exportOvertureFmu = Overture.exportOvertureFmu;
 
 
 Menus.configureIntoCpsMenu();

--- a/src/overture.html
+++ b/src/overture.html
@@ -1,0 +1,12 @@
+<div id="popup1" style="display: none; width: 650px; height: 400px; overflow: auto">
+    <div rel="title">
+        Popup #1 Title
+    </div>
+    <div rel="body">
+        <div style="padding: 10; font-size: 11px; line-height: 150%;" id="hgfgfhg">
+			
+           
+        </div>
+    </div>
+   
+</div>

--- a/src/overture.ts
+++ b/src/overture.ts
@@ -1,0 +1,57 @@
+
+import { IntoCpsApp } from "./IntoCpsApp";
+
+import * as fs from 'fs';
+import * as Path from 'path';
+
+import { SettingKeys } from "./settings/SettingKeys";
+import * as child_process from "child_process";
+
+export namespace Overture {
+
+    export function exportOvertureFmu(type: string, path: string) {
+        console.log("Exporting Overture FMU from path: " + path)
+        let toolName = "overture-fmu-cli.jar";
+        var jar = Path.join(IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_DIR), toolName);
+        if (!fs.existsSync(jar)) {
+            jar = Path.join(IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_TMP_DIR), toolName);
+        }
+
+        const { dialog } = require('electron').remote
+
+        if (fs.existsSync(jar)) {
+            var spawn = child_process.spawn;
+            console.log(jar);
+
+
+            var child = spawn('java', ['-jar', jar, "-export", type, "-name", Path.basename(path), "-output", IntoCpsApp.getInstance().getActiveProject().getFmusPath(), "-root", "."], {
+                detached: true,
+                shell: false,
+                cwd: path
+            });
+            child.unref();
+            child.stdout.on('data', function (data: any) {
+                console.log(""+data);
+            });
+
+
+            var errorMessages = "";
+            child.stderr.on('data', (data: any) => {
+                console.log('stderr: ' + data);
+                errorMessages += data;
+                // dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: "" + data }, function (button: any) { });
+            });
+
+            child.on('close', (code) => {
+                if (errorMessages != "") {
+                    dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: errorMessages }, function (button: any) { });
+                }
+
+            })
+        } else {
+            dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: "Please install: " + toolName + " first." }, function (button: any) { });
+        }
+    };
+
+
+}

--- a/src/overture.ts
+++ b/src/overture.ts
@@ -9,47 +9,73 @@ import * as child_process from "child_process";
 
 export namespace Overture {
 
+    function processStdOutData(data: any, div: HTMLDivElement, isErrorStream: boolean = false) {
+        let dd = (data + "").split("\n");
+
+        dd.forEach(line => {
+            if (line.trim().length != 0) {
+                let m = <HTMLSpanElement>document.createElement("span");
+                m.innerHTML = line + "<br/>";
+                if (isErrorStream)
+                    m.style.color = "rgb(255, 0, 0)";
+
+                div.appendChild(m);
+                m.scrollIntoView();
+            }
+        });
+    }
+
     export function exportOvertureFmu(type: string, path: string) {
+        const { dialog } = require('electron').remote
         console.log("Exporting Overture FMU from path: " + path)
         let toolName = "overture-fmu-cli.jar";
         var jar = Path.join(IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_DIR), toolName);
         if (!fs.existsSync(jar)) {
             jar = Path.join(IntoCpsApp.getInstance().getSettings().getValue(SettingKeys.INSTALL_TMP_DIR), toolName);
         }
-
-        const { dialog } = require('electron').remote
-
         if (fs.existsSync(jar)) {
-            var spawn = child_process.spawn;
-            console.log(jar);
+            w2popup.load({
+                showClose       : true,
+                title: 'Overture FMU Export',
+                url: 'overture.html', onOpen: function () {
+                    console.log('opened');
+                    let div = <HTMLDivElement>document.getElementById("hgfgfhg");
+                    var spawn = child_process.spawn;
+                    console.log(jar);
 
+                    var child = spawn('java', ['-jar', jar, "-v", "-export", type, "-name", Path.basename(path), "-output", IntoCpsApp.getInstance().getActiveProject().getFmusPath(), "-root", "."], {
+                        detached: true,
+                        shell: false,
+                        cwd: path
+                    });
+                    child.unref();
+                    child.stdout.on('data', function (data: any) {
+                        console.log("" + data);
+                        processStdOutData(data, div);
 
-            var child = spawn('java', ['-jar', jar, "-export", type, "-name", Path.basename(path), "-output", IntoCpsApp.getInstance().getActiveProject().getFmusPath(), "-root", "."], {
-                detached: true,
-                shell: false,
-                cwd: path
-            });
-            child.unref();
-            child.stdout.on('data', function (data: any) {
-                console.log(""+data);
-            });
+                    });
 
+                    var errorMessages = "FMU Export Failed with Following Errors:\n";
 
-            var errorMessages = "";
-            child.stderr.on('data', (data: any) => {
-                console.log('stderr: ' + data);
-                errorMessages += data;
-                // dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: "" + data }, function (button: any) { });
-            });
+                    child.stderr.on('data', (data: any) => {
+                        console.log('stderr: ' + data);
+                        errorMessages += data;
+                        processStdOutData(data, div, true);
+                    });
 
-            child.on('close', (code) => {
-                if (errorMessages != "") {
-                    dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: errorMessages }, function (button: any) { });
+                    child.on('close', (code) => {
+                        if (code != 0) {
+                            processStdOutData("Export Failed.", div, true);
+                            //                            dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: errorMessages }, function (button: any) { });
+                        } else {
+                            processStdOutData("FMU Export Complete: " + Path.basename(path) + ".fmu", div, false);
+                        }
+                    })
                 }
 
-            })
+            }); // content loaded from the server
         } else {
-            dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: "Please install: " + toolName + " first." }, function (button: any) { });
+            dialog.showMessageBox({ type: 'error', buttons: ["OK"], message: "Please install: " + "Overture FMU Import / Exporter CLI - Overture FMI Support" + " first." }, function (button: any) { });
         }
     };
 

--- a/src/proj/projbrowserview.ts
+++ b/src/proj/projbrowserview.ts
@@ -602,6 +602,15 @@ export class BrowserController {
             else if (this.isOvertureProject(path)) {
                 result.img = "into-cps-icon-projbrowser-overture";
                 result.expanded = false;
+                let menuEntryExportFmuSourceCode = menuEntry("Export Source Code FMU", "glyphicon glyphicon-export",
+                    function (item: ProjectBrowserItem) {
+                        self.menuHandler.exportOvertureFmu("source",item.path);
+                    });
+                let menuEntryExportFmuToolWrapper = menuEntry("Export Tool Wrapper FMU", "glyphicon glyphicon-export",
+                    function (item: ProjectBrowserItem) {
+                        self.menuHandler.exportOvertureFmu("tool",item.path);
+                    });
+                result.menuEntries = [menuEntryExportFmuSourceCode,menuEntryExportFmuToolWrapper];
             }
             else if (Path.basename(path) == Project.PATH_DSE) {
                 let menuEntryCreate = menuEntry("Create Design Space Exploration Config", "glyphicon glyphicon-asterisk",


### PR DESCRIPTION
This adds the option to right click on a VDM Model folder in the app and export the FMU to the FMUs folder as either tool or source. It uses the fmu exporter cli which must be downloaded for.


I by mistake already added the overture.ts to master but also included it here.