### PR TITLE
Adding a fresh filename generator to be used in the creation of new m…

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as Path from 'path';
 import { DseConfiguration } from "./intocps-configurations/dse-configuration"
 
-import {TraceMessager} from "./traceability/trace-messenger"
+import { TraceMessager } from "./traceability/trace-messenger"
 
 interface MyWindow extends Window {
     ng2app: AppComponent;
@@ -219,32 +219,32 @@ menuHandler.createMultiModel = (path, msgTitle = 'New Multi-Model') => {
     let project = appInstance.getActiveProject();
 
     if (project) {
-        let name    = Path.basename(path, ".sysml.json");
-        let ivname  = project.freshMultiModelName(`mm-${name}`);
-        let mmPath  = null; 
+        let name = Path.basename(path, ".sysml.json");
+        let ivname = project.freshMultiModelName(`mm-${name}`);
+        let mmPath = null;
         w2prompt({
-            label       : 'Name',
-            value       : ivname,
-            attrs       : 'style="width: 500px"',
-            title       : msgTitle,
-            ok_text     : 'Ok',
-            cancel_text : 'Cancel',
-            width       : 500,
-            height      : 200,
-            callBack    : function (value : String) {
+            label: 'Name',
+            value: ivname,
+            attrs: 'style="width: 500px"',
+            title: msgTitle,
+            ok_text: 'Ok',
+            cancel_text: 'Cancel',
+            width: 500,
+            height: 200,
+            callBack: function (value: String) {
 
                 let content = fs.readFileSync(path, "UTF-8");
                 try {
-                    if (!value) {return;}
+                    if (!value) { return; }
                     mmPath = <string>project.createMultiModel(value, content);
                     menuHandler.openMultiModel(mmPath);
-                } catch (error){
-                    menuHandler.createMultiModel(path,'Multi-Model "'+  value + '" already exists! Choose a different name.');
+                } catch (error) {
+                    menuHandler.createMultiModel(path, 'Multi-Model "' + value + '" already exists! Choose a different name.');
                     return;
                 }
                 //Create the trace 
                 if (mmPath) {
-                    let message = TraceMessager.submitSysMLToMultiModelMessage(mmPath,path);
+                    let message = TraceMessager.submitSysMLToMultiModelMessage(mmPath, path);
                     //console.log("RootMessage: " + JSON.stringify(message));    
                 }
             }
@@ -276,44 +276,69 @@ menuHandler.createDsePlain = () => {
     }
 }
 
-menuHandler.createMultiModelPlain = (titleMsg : string = 'New Multi-Model') => {
+menuHandler.createMultiModelPlain = (titleMsg: string = 'New Multi-Model') => {
     let project = IntoCpsApp.getInstance().getActiveProject();
 
     if (project) {
-
-        let ivname  =  project.freshMultiModelName(`mm-new`);  
-
+        let ivname = project.freshMultiModelName(`mm-new`);
         w2prompt({
-            label       : 'Name',
-            value       : ivname,
-            attrs       : 'style="width: 500px"',
-            title       : titleMsg,
-            ok_text     : 'Ok',
-            cancel_text : 'Cancel',
-            width       : 500,
-            height      : 200,
-            callBack    : function (value : String) {
+            label: 'Name',
+            value: ivname,
+            attrs: 'style="width: 500px"',
+            title: titleMsg,
+            ok_text: 'Ok',
+            cancel_text: 'Cancel',
+            width: 500,
+            height: 200,
+            callBack: function (value: String) {
                 try {
-                   if (!value) {return;}
-                   let mmPath = <string>project.createMultiModel(value, "{}");
-                   menuHandler.openMultiModel(mmPath);
-                } catch (error){                   
-                   menuHandler.createMultiModelPlain('Multi-Model "'+  value + '" already exists! Choose a different name.');
+                    if (!value) { return; }
+                    let mmPath = <string>project.createMultiModel(value, "{}");
+                    menuHandler.openMultiModel(mmPath);
+                } catch (error) {
+                    menuHandler.createMultiModelPlain('Multi-Model "' + value + '" already exists! Choose a different name.');
                 }
             }
-    });
+        });
 
     }
 };
 
 
 menuHandler.createCoSimConfiguration = (path) => {
-    let project = IntoCpsApp.getInstance().getActiveProject();
+
+    let appInstance = IntoCpsApp.getInstance();
+    let project = appInstance.getActiveProject();
 
     if (project) {
-        let coePath = project.createCoSimConfig(path, `co-sim-${Math.floor(Math.random() * 100)}`, null).toString();
-        menuHandler.openCoeView(coePath);
-        let message = TraceMessager.submitCoeConfigMessage(path,coePath);
+        //let name    = Path.basename(path, ".sysml.json");
+        let ivname = project.freshFilename(Path.dirname(path), `co-sim`);
+
+        let msgTitle = 'New Co-Simulation Configuration';
+        w2prompt({
+            label: 'Name',
+            value: ivname,
+            attrs: 'style="width: 500px"',
+            title: msgTitle,
+            ok_text: 'Ok',
+            cancel_text: 'Cancel',
+            width: 500,
+            height: 200,
+            callBack: function (value: String) {
+                try {
+                    if (!value) { return; }
+
+                    let coePath = project.createCoSimConfig(path, value, null).toString();
+                    menuHandler.openCoeView(coePath);
+
+                    if (coePath) {
+                        let message = TraceMessager.submitCoeConfigMessage(path, coePath);
+                    }
+                } catch (error) {
+                    return;
+                }
+            }
+        });
     }
 };
 
@@ -357,7 +382,7 @@ menuHandler.showTraceView = () => {
     let renameHandler = new DialogHandler("traceability/traceHints.html", 600, 800, null, null, null);
 
     renameHandler.openWindow();
-    menuHandler.openHTMLInMainView("http://localhost:7474/browser/","Traceability Graph View");
+    menuHandler.openHTMLInMainView("http://localhost:7474/browser/", "Traceability Graph View");
 };
 
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -220,7 +220,7 @@ menuHandler.createMultiModel = (path, msgTitle = 'New Multi-Model') => {
 
     if (project) {
         let name    = Path.basename(path, ".sysml.json");
-        let ivname  = `mm-${name}`;
+        let ivname  = project.freshMultiModelName(`mm-${name}`);
         let mmPath  = null; 
         w2prompt({
             label       : 'Name',
@@ -281,8 +281,7 @@ menuHandler.createMultiModelPlain = (titleMsg : string = 'New Multi-Model') => {
 
     if (project) {
 
-        let ivname  = `mm-new`;
-        
+        let ivname  =  project.freshMultiModelName(`mm-new`);  
 
         w2prompt({
             label       : 'Name',

--- a/src/proj/IProject.ts
+++ b/src/proj/IProject.ts
@@ -16,4 +16,5 @@ export interface IProject {
     getSettings(): ProjectSettings;
 
     freshMultiModelName(name : String): String;
+    freshFilename(path: string, name: string) : string
 }

--- a/src/proj/IProject.ts
+++ b/src/proj/IProject.ts
@@ -14,4 +14,6 @@ export interface IProject {
     createCoSimConfig(multimodelConfigPath: string, name: String, jsonContent: String): string;
 
     getSettings(): ProjectSettings;
+
+    freshMultiModelName(name : String): String;
 }

--- a/src/proj/Project.ts
+++ b/src/proj/Project.ts
@@ -11,7 +11,10 @@ export class Project implements IProject {
     name: string;
     rootPath: string;
     configPath: string;
-
+    /**
+     * The maximum number to be concatenated to filenames when a fresh name is needed
+     */
+    MAX_NEW_FILENAME: number = 100; 
 
 
     PATH_FMUS: String = "FMUs";
@@ -166,7 +169,37 @@ export class Project implements IProject {
     }
 
 
+    public freshMultiModelName(name : string): string { 
+        return this.freshFilename(Path.normalize(this.rootPath + "/" + Project.PATH_MULTI_MODELS),name); 
+    }
 
+
+    /**
+     * Returns a fresh filename inside folder path with name as a prefix. 
+     * @param {string} path 
+     * @param {string} name 
+     */
+    private freshFilename(path: string, name: string) : string
+    {
+        var filepath : string;
+        var newname : string = name; 
+
+        for (var i = 1; i < this.MAX_NEW_FILENAME; i++)
+            {
+                filepath = Path.format({ dir : path,
+                                         base : newname, 
+                                         root : null, 
+                                         name : null, 
+                                         ext : null
+                                        });
+
+                if(!fs.existsSync(filepath)) return newname;        
+
+                newname = name + i;
+            }
+            
+        return name;
+    }
 
 
 

--- a/src/proj/Project.ts
+++ b/src/proj/Project.ts
@@ -179,7 +179,7 @@ export class Project implements IProject {
      * @param {string} path 
      * @param {string} name 
      */
-    private freshFilename(path: string, name: string) : string
+    public freshFilename(path: string, name: string) : string
     {
         var filepath : string;
         var newname : string = name; 
@@ -195,7 +195,7 @@ export class Project implements IProject {
 
                 if(!fs.existsSync(filepath)) return newname;        
 
-                newname = name + i;
+                newname = name +'-'+ i;
             }
             
         return name;


### PR DESCRIPTION
…ulti-models.

When a user creates multi-models the name suggested in the dialog box is the first non-existing file in the range: new-mm, new-mm1, ..., new-mm99. In case all the 100 default names are already used the user must manually insert a new name in the dialog box.

The same holds for multi-models created from existing SysML configuration files, but in that case the range is: $name, $name1, ..., $name99 where $name is the SysML configuration filename from which the model is being created.