### PR TITLE
enable simple markdown readme.md to be shown on project open if the file exists in the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "request-progress": "~2.0.1",
     "rimraf": "~2.5.4",
     "rxjs": "5.0.0-beta.6",
+    "showdown": "^1.7.1",
     "sql.js": "~0.3.2",
     "tree-kill": "~1.1.0",
     "typescript": "~2.1.5",

--- a/src/IntoCpsApp.ts
+++ b/src/IntoCpsApp.ts
@@ -141,9 +141,15 @@ export default class IntoCpsApp extends EventEmitter {
         if (this.window != undefined) {
             // Fire an event to inform all controlls on main window that the project has changed
             this.window.webContents.send(IntoCpsAppEvents.PROJECT_CHANGED);
+            this.window.reload();
             console.info("fire event: " + event);
         }
-        this.emit(IntoCpsAppEvents.PROJECT_CHANGED);
+        try {
+            this.emit(IntoCpsAppEvents.PROJECT_CHANGED);
+        } catch (error) {
+
+        }
+
     }
 
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -18,8 +18,9 @@ import { AppComponent } from './angular2-app/app.component';
 import * as fs from 'fs';
 import * as Path from 'path';
 import { DseConfiguration } from "./intocps-configurations/dse-configuration"
+import * as ShowdownHelper  from "./showdownHelper";
 
-import { TraceMessager } from "./traceability/trace-messenger"
+import {TraceMessager} from "./traceability/trace-messenger"
 
 interface MyWindow extends Window {
     ng2app: AppComponent;
@@ -83,6 +84,11 @@ class InitializationController {
             var appVer = (<HTMLSpanElement>document.getElementById('appVersion'));
             appVer.innerText = IntoCpsApp.getInstance().app.getVersion();
 
+            let divReadme = (<HTMLDivElement>document.getElementById("mainReadmeView"));
+
+            let  readmePath = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"Readme.md");
+            divReadme.innerHTML=ShowdownHelper.getHtml(readmePath);
+            
             // Start Angular 2 application
             bootstrap(AppComponent, [disableDeprecatedForms(), provideForms()]);
         });

--- a/src/init.ts
+++ b/src/init.ts
@@ -86,9 +86,29 @@ class InitializationController {
 
             let divReadme = (<HTMLDivElement>document.getElementById("mainReadmeView"));
 
-            let  readmePath = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"Readme.md");
-            divReadme.innerHTML=ShowdownHelper.getHtml(readmePath);
-            
+            let  readmePath1 = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"Readme.md");
+            let  readmePath2 = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"readme.md");
+            let  readmePath3 = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"README.MD");
+            let  readmePath4 = Path.join( IntoCpsApp.getInstance().getActiveProject().getRootFilePath(),"README.md");
+
+            let theHtml1 = ShowdownHelper.getHtml(readmePath1);
+            let theHtml2 = ShowdownHelper.getHtml(readmePath2);
+            let theHtml3 = ShowdownHelper.getHtml(readmePath3);
+            let theHtml4 = ShowdownHelper.getHtml(readmePath4);
+
+            if(theHtml1 != null){
+                divReadme.innerHTML = theHtml1;
+            }
+            else if(theHtml2 != null){
+                divReadme.innerHTML = theHtml2;
+            }
+            else if(theHtml3 != null){
+                divReadme.innerHTML = theHtml3;
+            }
+            else if(theHtml4 != null){
+                divReadme.innerHTML = theHtml4;
+            }
+
             // Start Angular 2 application
             bootstrap(AppComponent, [disableDeprecatedForms(), provideForms()]);
         });

--- a/src/main.html
+++ b/src/main.html
@@ -12,6 +12,9 @@
   <h3 class="left-pad"> INTO-CPS  &gt; <span id="activeTabTitle">welcome</span></h3>
 </div>
 
-<div class="full-width container-fluid" id="mainView" style="height: calc(100% - 80px)">Welcome to the INTO-CPS Application version <span id="appVersion"></span></div>
+<div class="full-width container-fluid" id="mainView" style="height: calc(100% - 80px)">Welcome to the INTO-CPS Application version <span id="appVersion"></span>
+<div class="full-width container-fluid" id="mainReadmeView" ></div>
+</div>
+
 
 <app></app>

--- a/src/showdownHelper.ts
+++ b/src/showdownHelper.ts
@@ -1,0 +1,19 @@
+
+import { IntoCpsApp } from "./IntoCpsApp";
+import * as fs from 'fs';
+import * as Path from 'path';
+
+export function getHtml(markdownFilePath: string): string {
+    var showdown = require('showdown'),
+        converter = new showdown.Converter()
+
+    //let markdownFilePath = Path.join(IntoCpsApp.getInstance().getActiveProject().getRootFilePath(), "Readme.md");
+    if (fs.existsSync(markdownFilePath)) {
+        var text = "" + fs.readFileSync(markdownFilePath);
+        text = text.split("](").join("](" + IntoCpsApp.getInstance().getActiveProject().getRootFilePath() + "/")
+        let html = converter.makeHtml(text);
+
+        return html;
+    }
+    return null;
+}


### PR DESCRIPTION
This is a simple implementation that shows readme.md on the main page on project open. It can handle markdown images as well (when the picture is relative to the root of the repo). The main issue is that users cannot see the description of the casestudies when they open them in the app. Issue is raised in #244

