### PR TITLE
This provides the ability to use a local downloaded update site

### DIFF
--- a/src/downloadManager/DownloadManager.ts
+++ b/src/downloadManager/DownloadManager.ts
@@ -87,6 +87,14 @@ function fetchList() {
 
     }
 
+    if (settings.getValue(SettingKeys.USE_LOCAL_UPDATE_SITE) && settings.getValue(SettingKeys.LOCAL_UPDATE_SITE) != "") {
+        url = settings.getValue(SettingKeys.LOCAL_UPDATE_SITE);
+    }
+
+    if (!(url + "").endsWith("/")) {
+        url = url + "/";
+    }
+
     var panel: HTMLInputElement = <HTMLInputElement>document.getElementById("tool-versions-panel");
 
     while (panel.hasChildNodes()) {

--- a/src/downloader/Downloader.ts
+++ b/src/downloader/Downloader.ts
@@ -2,12 +2,51 @@ import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as http from "http";
-import {Utilities} from "../utilities"
+import { Utilities } from "../utilities"
 let request = require("request");
+
 let progress = require("request-progress");
+let fsProgress = require('progress-stream');
 let hash = require("md5-promised");
 let yauzl = require("yauzl");
 let mkdirp = require("mkdirp");
+
+var previousVersionsLocalPath = "";
+
+function isUrlLocal(url: any): boolean {
+    return url.startsWith("file:");
+}
+
+
+function requestProxy(options: any, callback?: any) {
+
+    if ("uri" in options || "url" in options) {
+        var urlPath = "";
+        var isLocal = false;
+        if (isUrlLocal(options["uri"] + "")) {
+            isLocal = true;
+            urlPath = options["uri"];
+        } else if (isUrlLocal(options["url"] + "")) {
+            isLocal = true;
+            urlPath = options["url"];
+        }
+
+        if (isLocal) {
+            //const { URL } = require('url');
+            var readJson = "json" in options && options["json"];
+
+            const URL = require('url').Url;
+            let u = new URL().parse(urlPath);
+            //readJson? JSON.parse(data+""):data
+            fs.readFile(u.path, (err, data) => {
+                callback(err, null, err == null && readJson ? JSON.parse(data + "") : data);
+            });
+            return;
+        }
+    }
+
+    return request(options, callback);
+}
 
 export function getSystemPlatform() {
     let arch: string = Utilities.getSystemArchitecture();
@@ -32,9 +71,12 @@ export const SYSTEM_PLATFORM = getSystemPlatform();
 export function fetchVersionList(url: string): Promise<any> {
     return new Promise<any>((resolve, reject) => {
         // let data = new Stream<string>();
-        request({ url: url, json: true }, function (
+        requestProxy({ url: url, json: true }, function (
             error: Error, response: http.IncomingMessage, body: any) {
-            if (!error && response.statusCode == 200) {
+            if (!error && (response == null || response.statusCode == 200)) {
+                if (isUrlLocal(url)) {
+                    previousVersionsLocalPath = url;
+                }
                 resolve(body);
             } else {
                 reject(error);
@@ -46,9 +88,9 @@ export function fetchVersionList(url: string): Promise<any> {
 
 export function fetchVersion(url: string): Promise<any> {
     return new Promise<any>((resolve, reject) => {
-        request({ url: url, json: true }, function (
+        requestProxy({ url: url, json: true }, function (
             error: Error, response: http.IncomingMessage, body: any) {
-            if (!error && response.statusCode == 200) {
+            if (!error && (response == null || response.statusCode == 200)) {
                 resolve(body);
             } else {
                 reject(error);
@@ -65,26 +107,82 @@ export function downloadTool(tool: any, targetDirectory: string, progressCallbac
     const filePath: string = path.join(targetDirectory, fileName);
     const md5sum: string = tool.platforms[platFormToUse].md5sum;
     return new Promise<any>((resolve, reject) => {
-        progress(request(url))
-            .on("progress", function (state: any) {
-                progressCallback(state);
-            })
-            .on("error", function (error: Error) {
-                reject(error);
-            })
-            .on("end", function () {
-                progressCallback(1);
-                hash(filePath).then(function (newMd5sum: string) {
-                    if (newMd5sum == md5sum) {
-                        resolve(filePath);
-                    } else {
-                        reject("Bad MD5 expected: '" + md5sum + "' got: '" + newMd5sum + "'");
-                    }
-                }, function (error: string) {
+
+        var p = null;
+
+        if (isUrlLocal(url)) {
+            const URL = require('url').Url;
+            var localUrl = url;
+            if (!localUrl.startsWith("file:/")) {
+
+                localUrl = path.join(path.dirname(previousVersionsLocalPath), new URL().parse(localUrl).path);
+            }
+
+            let localPath = new URL().parse(localUrl).path;
+            var stat = fs.statSync(localPath);
+            var str = fsProgress({
+                length: stat.size,
+                time: 100 /* ms */
+            });
+
+            str.on('progress', function (progress: any) {
+                var p: any = {};
+                p["percentage"] = progress.percentage / 100;
+                progressCallback(p);
+
+                if (progress.percentage >= 100) {
+                    progressCallback(1);
+                    hash(filePath).then(function (newMd5sum: string) {
+                        if (newMd5sum == md5sum) {
+                            resolve(filePath);
+                        } else {
+                            reject("Bad MD5 expected: '" + md5sum + "' got: '" + newMd5sum + "'");
+                        }
+                    }, function (error: string) {
+                        reject(error);
+                    });
+                }
+                /*
+                {
+                    percentage: 9.05,
+                    transferred: 949624,
+                    length: 10485760,
+                    remaining: 9536136,
+                    eta: 42,
+                    runtime: 3,
+                    delta: 295396,
+                    speed: 949624
+                }
+                */
+            });
+
+            p = fs.createReadStream(localPath)
+                .pipe(str);
+
+
+        } else {
+
+            p = progress(request(url))
+                .on("progress", function (state: any) {
+                    progressCallback(state);
+                })
+                .on("error", function (error: Error) {
                     reject(error);
+                })
+                .on("end", function () {
+                    progressCallback(1);
+                    hash(filePath).then(function (newMd5sum: string) {
+                        if (newMd5sum == md5sum) {
+                            resolve(filePath);
+                        } else {
+                            reject("Bad MD5 expected: '" + md5sum + "' got: '" + newMd5sum + "'");
+                        }
+                    }, function (error: string) {
+                        reject(error);
+                    });
                 });
-            })
-            .pipe(fs.createWriteStream(filePath));
+        }
+        p.pipe(fs.createWriteStream(filePath));
     });
 }
 
@@ -102,7 +200,7 @@ function launchToolInstaller(filePath: string) {
 }
 
 
-export function toolRequiresUnpack(tool: any){
+export function toolRequiresUnpack(tool: any) {
     let platFormToUse = tool.platforms.any ? "any" : SYSTEM_PLATFORM;
     const action: string = tool.platforms[platFormToUse].action;
     return action === "unpack";
@@ -110,34 +208,34 @@ export function toolRequiresUnpack(tool: any){
 
 export function unpackTool(filePath: string, targetDirectory: string) {
     return new Promise((resolve, reject) => {
-        yauzl.open(filePath, {lazyEntries: true}, function(err  : any, zipfile : any) {
-        if (err) throw err;
-        zipfile.readEntry();
-        zipfile.on("entry", function(entry : any) {
-            let desiredPath = path.join(targetDirectory, entry.fileName);
-            //let desiredPath = targetDirectory + entry.fileName;
-            if (/\/$/.test(entry.fileName)) {
-            // directory file names end with '/'
-            mkdirp(desiredPath, function(err : any) {
-                if (err) throw err;
-                zipfile.readEntry();
+        yauzl.open(filePath, { lazyEntries: true }, function (err: any, zipfile: any) {
+            if (err) throw err;
+            zipfile.readEntry();
+            zipfile.on("entry", function (entry: any) {
+                let desiredPath = path.join(targetDirectory, entry.fileName);
+                //let desiredPath = targetDirectory + entry.fileName;
+                if (/\/$/.test(entry.fileName)) {
+                    // directory file names end with '/'
+                    mkdirp(desiredPath, function (err: any) {
+                        if (err) throw err;
+                        zipfile.readEntry();
+                    });
+                } else {
+                    // file entry
+                    zipfile.openReadStream(entry, function (err: any, readStream: any) {
+                        if (err) throw err;
+                        // ensure parent directory exists
+                        mkdirp(path.dirname(desiredPath), function (err: any) {
+                            if (err) throw err;
+                            readStream.pipe(fs.createWriteStream(desiredPath));
+                            readStream.on("end", function () {
+                                zipfile.readEntry();
+                                resolve();
+                            });
+                        });
+                    });
+                }
             });
-            } else {
-            // file entry
-            zipfile.openReadStream(entry, function(err : any, readStream : any) {
-                if (err) throw err;
-                // ensure parent directory exists
-                mkdirp(path.dirname(desiredPath), function(err : any) {
-                if (err) throw err;
-                readStream.pipe(fs.createWriteStream(desiredPath));
-                readStream.on("end", function() {
-                    zipfile.readEntry();
-                    resolve();
-                });
-                });
-            });
-            }
-        });
         });
     });
 }

--- a/src/settings/SettingKeys.ts
+++ b/src/settings/SettingKeys.ts
@@ -19,6 +19,8 @@ export namespace SettingKeys {
     export var DEV_EXAMPLE_REPO = "dev_example_site";
     export var DEFAULT_PROJECTS_FOLDER_PATH = "default_projects_folder_path";
     export var ENABLE_TRACEABILITY = "enable_traceability";
+    export var LOCAL_UPDATE_SITE = "local_update_site";
+    export var USE_LOCAL_UPDATE_SITE = "use_local_update_site";
 
     export var DEFAULT_VALUES: { [key: string]: any; } = {};
     DEFAULT_VALUES[RTTESTER_INSTALL_DIR] = 'C:/opt/rt-tester';
@@ -35,4 +37,6 @@ export namespace SettingKeys {
     DEFAULT_VALUES[COE_DEBUG_ENABLED] = false;
     DEFAULT_VALUES[COE_REMOTE_HOST] = false;
     DEFAULT_VALUES[ENABLE_TRACEABILITY] = false;
+    DEFAULT_VALUES[LOCAL_UPDATE_SITE] = "";
+     DEFAULT_VALUES[USE_LOCAL_UPDATE_SITE] = false;
 }


### PR DESCRIPTION
This feature enabled the complete update site to be used from a local file system. The update site already contains a python script to generate a local version of the repo for use on USB sticks.

The implementation here enables support for the schema: `file:` where the previous implementation only supported `url:`.

The update should have no affect if the user doesn't enable it.

Related to findings at the summerschool: https://github.com/into-cps/intocps-ui/issues/244